### PR TITLE
Don't fill callout SVGs

### DIFF
--- a/themes/github/index.css
+++ b/themes/github/index.css
@@ -33,7 +33,6 @@
 
 .callout-hint > svg {
 	margin-right: 0.5rem;
-	fill: currentColor;
 	display: inline-block;
 	vertical-align: text-bottom;
 }


### PR DESCRIPTION
Otherwise icons are filled completely.

Without this change for example the `assert` callout icon looks like this:

![2025-01-14T11:41:39,751402993+01:00](https://github.com/user-attachments/assets/36083963-3a3f-4ae7-a468-3f6bdfb56f31)

After removing this rule it looks correct again:

![2025-01-14T11:42:23,619779265+01:00](https://github.com/user-attachments/assets/92c691a0-989b-4857-a262-44cc8ea4adcd)
